### PR TITLE
Reported distances are inconsistent/wrong

### DIFF
--- a/src/ted.coffee
+++ b/src/ted.coffee
@@ -74,8 +74,6 @@ ted = (rootA, rootB, childrenCb, insertCb, removeCb, updateCb) ->
 				t.keyroots.push nIndex
 			return
 
-		t.keyroots.sort()
-
 		return t
 
 	treeDistance = (i, j) ->

--- a/test/ted.test.coffee
+++ b/test/ted.test.coffee
@@ -75,6 +75,8 @@ describe 'Tree Edit Distance', ->
 		shouldBeSymmetrical "((a,(b)c)d,e)f", "(((a,b)d)c,e)f", 2, [["f", "f"], ["e", "e"], [null, "c"], ["d", "d"], ["c", null], ["b", "b"], ["a", "a"]]
 		shouldBeSymmetrical "((a,(b)c)d,e)f", "(((a,b)d)c,x)f", 3, [["f", "f"], ["e", "x"], [null, "c"], ["d", "d"], ["c", null], ["b", "b"], ["a", "a"]]
 		shouldBeSymmetrical "((a,(b)c)d,e)f", "(((a,b)d,e)c)f", 2, [["f", "f"], [null, "c"], ["e", "e"], ["d", "d"], ["c", null], ["b", "b"], ["a", "a"]]
+		shouldBeSymmetrical "((a,(b)c)d,e)f", "(((a,b)d,e)c)f", 2, [["f", "f"], [null, "c"], ["e", "e"], ["d", "d"], ["c", null], ["b", "b"], ["a", "a"]]
+		shouldBeSymmetrical "((a,b,(c,d)e,f,g,(h,(i)j)k,l)m)n", "((a,b,(c,d)e,f,g,(h,(i)x)k,l)m)n", 1, [["n", "n"], ["m", "m"], ["l", "l"], ["k", "k"], ["j", "x"], ["i", "i"], ["h", "h"], ["g", "g"], ["f", "f"], ["e", "e"], ["d", "d"], ["c", "c"], ["b", "b"], ["a", "a"]]
 
 	describeBenchmark = if process.env.BENCHMARK then describe else describe.skip
 	describeBenchmark 'should be performant', ->


### PR DESCRIPTION
First thanks for your work on this library. I'm currently researching into tree differencing algorithms and it made the implementation of Zhang-Shasha straight forward. Porting this algorithm to TypeScript, I encountered some inconsistencies. I compared the following two trees:

``` coffee
a = "((((0)1)1)1,0,0,0,0,(((((0)1)1,(0)1,((0,0)2)1,(0,(0,((0,0,0)3,(((0,0)2)1)1)2)2)2,(((((0)1)1,((0,0)2)1)2)1)1)5)1)1,(((((0)1,(0)1)2)1)1,((((((((0)1)1,((((0)1)1,((0,0)2)1)2)1,((0,0,0,(0,((0)1,(0)1,(0)1)3)2)4,(0)1,(0,0,(0,((0)1,(0)1,(0)1,(0)1,(0)1,(0)1)6)2)3,(0)1,(0)1,(0)1,(0)1,(0)1,(0)1,(0)1)10)3)1)1)1,((((0,((0)1,(0)1,(0)1)3)2)1)1)1,(((0,0)2,(0)1,(0,0)2,((0)1)1,(0)1,(0)1,((0)1,(0)1)2,(0)1,((0)1,(0,0,0,0,0,0)6)2,(0)1,((0)1,(0)1,((0,0)2)1)3,(0)1)12)1)3)1,((((((0)1)1,(0)1)2)1)1,(((0,0,0)3,(0,0,0,0,0)5)2)1)2)3,0,0,0)10"
b = "((((0)1)1)1,0,0,0,0,(((((0)1)1,(0)1,((0,0)2)1,(0,(0,((0,0,0)3,(((0,0)2)1)1)2)2)2,(((((0)1)1,((0,0)2)1)2)1)1)5)1)1,(((((0)1,(0)1)2)1)1,((((((((0)1)1,((((0)1)1,((0,0)2)1)2)1,((0)1,(0)1,(0,0,(0,((0)1,(0)1,(0)1,(0)1,(0)1,(0)1)6)2)3,(0)1,(0)1,(0)1,(0)1,(0,0,0,(0,((0)1,(0)1)2)2)4,(0)1,(0)1)10)3)1)1)1,((((0,((0)1,(0)1)2)2)1)1)1,(((0)1,(0,0)2,(0)1,(0)1,(0)1,0,0)7)1)3)1,(((((0)1,((0)1)1)2,(((0)1)1,(0)1)2)2)1,(((0,0,0)3,(0,0,0,0,0)5)2)1)2)3,0,0,0)10"
```

Tree edit distance should be symmetric, but the distances reported are `= 50` for `(a, b)` and `= 42` for `(b,a)`. Next I tried to construct a reproducible test case. The following two trees (which I also added within the tests) should generate one relabel operation, but the algorithm returns `= 0` as a distance:

``` coffee
a = "((a,b,(c,d)e,f,g,(h,(i)j)k,l)m)n"
b = "((a,b,(c,d)e,f,g,(h,(i)x)k,l)m)n"
```

Debugging the process of matching, I found that the keyroots are in the wrong order:

``` coffee
keyroots = [ 1, 10, 11, 13, 3, 4, 5, 6, 9 ]
```

This is due to the natural sorting that is done at the end of the preprocessing step. Removing the sorting fixes the error - the keyroots are in the right order anyway as the tree was consistently traversed in post-order.

As a result, the initial two trees now compare both ways with a distance of `= 63`.