### PR TITLE
Replace charAt with index notation in levenshtein.coffee

### DIFF
--- a/src/levenshtein.coffee
+++ b/src/levenshtein.coffee
@@ -28,8 +28,8 @@ levenshtein = (stringA, stringB, insertCb, removeCb, updateCb) ->
 
 	for i in [1..a.length] by 1
 		for j in [1..b.length] by 1
-			aC = a.charAt(i - 1)
-			bC = b.charAt(j - 1)
+			aC = a[i - 1]
+			bC = b[j - 1]
 			min = trackedMin(
 				 dist[i - 1][j] + removeCb(aC),
 				 dist[i][j - 1] + insertCb(bC),


### PR DESCRIPTION
Using charAt restricts the library's usage to comparing strings
only. Using plain index notation allows to use it on arbitrary
lists as well: e. g. for calculating the levenshtein distance
in words between tokenized texts.